### PR TITLE
use alias_method instead of instance variable

### DIFF
--- a/lib/dude.rb
+++ b/lib/dude.rb
@@ -1,9 +1,7 @@
 class Exception
-  def initialize(message)
-    @message = message
-  end
+  alias_method :__old_to_s, :to_s
 
   def to_s
-    "#{@message}, dude."
+    "#{__old_to_s}, dude."
   end
 end


### PR DESCRIPTION
There is no need for an instance variable and overriding the initialize method
