### PR TITLE
removed minitest from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'minitest'
 # Specify your gem's dependencies in dude.gemspec
 gemspec


### PR DESCRIPTION
@strand I know you added minitest to the `Gemfile` and I don't know why. But there is no need to have it there. It's already specified at `dude.gemspec` and I believe that's where bundler pick the dependencies for gems.
